### PR TITLE
added html entity parsing in titles printed to channel

### DIFF
--- a/BigBen
+++ b/BigBen
@@ -7,6 +7,7 @@ import thread
 import os
 import random
 import commands
+import HTMLParser
 pubTimeCommand = ".time"
 privTimeCommand = ".time"
 sayCommand = ".speak"
@@ -14,6 +15,7 @@ PMTimeCommand = ".ptime"
 log = "no"
 logfile = "users.txt"
 amounts = []
+HTMLParserObject = HTMLParser.HTMLParser()
 class Bot(ircbot.SingleServerIRCBot):
     def __init__ (self, channels, nick, server, port, password, name, silentChannels):
         ircbot.SingleServerIRCBot.__init__(self, [(server,port)], nick, name, 10)
@@ -136,7 +138,7 @@ class Bot(ircbot.SingleServerIRCBot):
                     title = commands.getoutput("curl -s " + "\"" + element + "\"" + " | awk -vRS=\"</title>\" '/<title>/{gsub(/.*<title>|\\n+/,\"\");print;exit}'")
                     if not title == "":
                         if not event.target() in self.silentChannels:
-                            self.connection.privmsg(event.target(), "Title: " + title)
+                            self.connection.privmsg(event.target(), "Title: " + HTMLParserObject.unescape(title))
                         
     def on_privmsg (self, connection, event):  #the user specifies the channel after the command
         eventList = event.arguments()[0].split(' ')


### PR DESCRIPTION
uses HTMLParser library that's included with Python - note, it's named html.parser in python 3, so we'll need to change that if we ever upgrade
